### PR TITLE
fixed einsum_path error by requesting optimize=False

### DIFF
--- a/vis_corex.py
+++ b/vis_corex.py
@@ -600,7 +600,7 @@ def calculate_log_latent(corex, X):
     batch_size = np.clip(int(ram * n_samples / memory_size), 1, n_samples)
     for l in range(0, n_samples, batch_size):
         log_marg_x = corex.calculate_marginals_on_samples(corex.theta, Xm[l:l+batch_size])  # LLRs for each sample, for each var.
-        log_p_y_given_x_unnorm[:, l:l+batch_size, :] = corex.log_p_y + np.einsum('ikl,ijkl->ijl', corex.alpha, log_marg_x)
+        log_p_y_given_x_unnorm[:, l:l+batch_size, :] = corex.log_p_y + np.einsum('ikl,ijkl->ijl', corex.alpha, log_marg_x, optimize=False)
     return normalize_latent(log_p_y_given_x_unnorm, n_hidden)
 
 def normalize_latent(log_p_y_given_x_unnorm, n_hidden):


### PR DESCRIPTION
When invoking `vis_corex.py` on the test_data.csv file, I had the following error in Py27 and Py36

```
Traceback (most recent call last):
  File "vis_corex.py", line 786, in <module>
    vis_rep(corexes[0], X, row_label=sample_names, column_label=variable_names, prefix=options.output, focus=options.focus, topk=options.topk)
  File "vis_corex.py", line 38, in vis_rep
    log_p_y_given_x = calculate_log_latent(corex, data)
  File "vis_corex.py", line 603, in calculate_log_latent
    log_p_y_given_x_unnorm[:, l:l+batch_size, :] = corex.log_p_y + np.einsum('ikl,ijkl->ijl', corex.alpha, log_marg_x)
  File "/usr/lib64/python2.7/site-packages/numpy/core/einsumfunc.py", line 1087, in einsum
    einsum_call=True)
  File "/usr/lib64/python2.7/site-packages/numpy/core/einsumfunc.py", line 710, in einsum_path
    "not match previous terms.", char, tnum)
ValueError: ("Size of label '%s' for operand %d does not match previous terms.", 'l', 1)
```

Taking from Numpy's github issue thread (https://github.com/numpy/numpy/issues/10343), I added an explicit `optimize=False` to einsum on line 603. This resolved the issue.

*System details:*
-Fedora26 release
-Python 2.7.15
-Python 3.6.5
-Numpy 1.14.0
