### PR TITLE
Implement clip of sig_ml to avoid divide by zero bug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,3 +17,8 @@ Changes in readme.md
 3. added `graphviz` installation instructions for Ubuntu users
 
 4. added `requirements.txt` which lets users to install all the dependencies with a single command `conda install --yes --file requirements.txt`
+
+## April 20 - 2020
+
+Added minimum value to sig_ml of 0.5 in function estimate_parameters. This prevents divide by zero in functional marginal_p.
+

--- a/corex.py
+++ b/corex.py
@@ -510,7 +510,8 @@ class Corex(object):
             n_obs = np.sum(p_y_given_x, axis=1).clip(0.1)  # m, k
             mean_ml = np.einsum('i,jik->jk', xi, p_y_given_x, optimize=False) / n_obs  # ML estimate of mean of Xi
             sig_ml = np.einsum('jik,jik->jk', (xi[np.newaxis, :, np.newaxis] - mean_ml[:, np.newaxis, :])**2, p_y_given_x, optimize=False) / (n_obs - 1).clip(0.01)  # UB estimate of sigma^2(variance)
-
+            sig_ml = sig_ml.clip(0.5) # To prevent divide by zero in marginal_p function
+            
             if not self.smooth_marginals:
                 return np.array([mean_ml, sig_ml])  # FOR EACH Y_j = k !!
             else:  # mu = lam mu_ml + 1-lam mu0 for lam minimizing KL divergence risk


### PR DESCRIPTION
Proposed solution for issue #19 
I have added the line:
`sig_ml = sig_ml.clip(0.5) # To prevent divide by zero in marginal_p function`
the estimate_parameters function in order to later divide by zero issue in the marginal_p function. As discussed in issue #19 , 0.5 is a somewhat arbitrary figure, however it seems to work well in practice. However you may wish to explore this further before implementing this fix.